### PR TITLE
Fix getCurrentUser to wait for loaded user

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { Auth, user, signInWithEmailAndPassword, createUserWithEmailAndPassword, signOut, sendPasswordResetEmail } from '@angular/fire/auth';
 import { User } from 'firebase/auth';
-import { Observable } from 'rxjs';
+import { Observable, firstValueFrom } from 'rxjs';
+import { take } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -30,8 +31,12 @@ export class AuthService {
   }
 
   //  Usuario actual
-  getCurrentUser() {
-    return this.auth.currentUser;
+  async getCurrentUser(): Promise<User | null> {
+    const current = this.auth.currentUser;
+    if (current) {
+      return current;
+    }
+    return firstValueFrom(this.user$.pipe(take(1)));
   }
 
   //  Recuperar Contraseña


### PR DESCRIPTION
## Summary
- ensure AuthService waits for user before returning current user

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@capacitor/cli' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685368efc4e08331b0af0934b96d4d32